### PR TITLE
Add missing is-active spinner CSS class, better multiline comment.

### DIFF
--- a/wp-admin/includes/options.php
+++ b/wp-admin/includes/options.php
@@ -82,10 +82,12 @@ function sae_options_general_add_js() {
 			});
 
 		$( 'form' ).submit( function() {
-			// Don't show a spinner for English and installed languages,
-			// as there is nothing to download.
+			/*
+			 * Don't show a spinner for English and installed languages, as
+			 * there is nothing to download.
+			 */
 			if ( ! $languageSelect.find( 'option:selected' ).data( 'installed' ) ) {
-				$( '#submit', this ).after( '<span class="spinner language-install-spinner" />' );
+				$( '#submit', this ).after( '<span class="spinner language-install-spinner is-active" />' );
 			}
 		});
 	});


### PR DESCRIPTION
Adds missing is-active spinner CSS class that was supposed to be added in #26.
Also makes a multiline comment meet the coding standards.